### PR TITLE
Fix panic when Keycloak cannot be reached

### DIFF
--- a/nss-keycloak/src/group.rs
+++ b/nss-keycloak/src/group.rs
@@ -21,17 +21,24 @@ impl GroupHooks for KeycloakNssGroup {
     /// Get all groups from Keycloak
     /// calls keycloak::list_groups underneath
     fn get_all_entries() -> Response<Vec<Group>> {
+        let access_token = match crate::AUTH.lock().unwrap().get_access_token() {
+            Ok(token) => token.clone(),
+            Err(err) => {
+                log::error!("Failed to get access token: {:?}", err);
+                return Response::TryAgain;
+            }
+        };
         match list_groups(
             &crate::CONFIG.keycloak,
             &crate::CONFIG.mapping,
-            crate::AUTH.lock().unwrap().get_access_token().unwrap(),
+            &access_token,
         ) {
             Ok(groups) => {
                 Response::Success(groups.into_iter().map(|group| Group::from(group)).collect())
             }
             Err(err) => {
                 log::error!("Failed to get all groups: {:?}", err);
-                Response::Unavail
+                Response::TryAgain
             }
         }
     }
@@ -42,17 +49,24 @@ impl GroupHooks for KeycloakNssGroup {
     /// Returns Response::NotFound if group is not found
     /// Returns Response::Unavail if there was an error
     fn get_entry_by_gid(gid: libc::gid_t) -> Response<Group> {
+        let access_token = match crate::AUTH.lock().unwrap().get_access_token() {
+            Ok(token) => token.clone(),
+            Err(err) => {
+                log::error!("Failed to get access token: {:?}", err);
+                return Response::TryAgain;
+            }
+        };
         match get_group_by_gid(
             &crate::CONFIG.keycloak,
             &crate::CONFIG.mapping,
-            crate::AUTH.lock().unwrap().get_access_token().unwrap(),
+            &access_token,
             gid,
         ) {
             Ok(None) => Response::NotFound,
             Ok(Some(group)) => Response::Success(Group::from(group)),
             Err(err) => {
                 log::error!("Failed to get group by gid: {:?}", err);
-                Response::Unavail
+                Response::TryAgain
             }
         }
     }
@@ -63,16 +77,23 @@ impl GroupHooks for KeycloakNssGroup {
     /// Returns Response::NotFound if group is not found
     /// Returns Response::Unavail if there was an error
     fn get_entry_by_name(name: String) -> Response<Group> {
+        let access_token = match crate::AUTH.lock().unwrap().get_access_token() {
+            Ok(token) => token.clone(),
+            Err(err) => {
+                log::error!("Failed to get access token: {:?}", err);
+                return Response::TryAgain;
+            }
+        };
         let group = get_group_by_name(
             &crate::CONFIG.keycloak,
             &crate::CONFIG.mapping,
-            crate::AUTH.lock().unwrap().get_access_token().unwrap(),
+            &access_token,
             &name,
         );
         match group {
             Err(err) => {
                 log::error!("Failed to get group by name: {:?}", err);
-                Response::Unavail
+                Response::TryAgain
             }
             Ok(None) => Response::NotFound,
             Ok(Some(group)) => Response::Success(Group::from(group)),

--- a/nss-keycloak/src/passwd.rs
+++ b/nss-keycloak/src/passwd.rs
@@ -22,49 +22,70 @@ impl From<KeycloakUser> for Passwd {
 
 impl PasswdHooks for KeycloakNssPasswd {
     fn get_all_entries() -> libnss::interop::Response<Vec<Passwd>> {
+        let access_token = match crate::AUTH.lock().unwrap().get_access_token() {
+            Ok(token) => token.clone(),
+            Err(err) => {
+                log::error!("Failed to get access token: {:?}", err);
+                return Response::TryAgain;
+            }
+        };
         match list_users(
             &crate::CONFIG.keycloak,
             &crate::CONFIG.mapping,
-            crate::AUTH.lock().unwrap().get_access_token().unwrap(),
+            &access_token,
         ) {
             Ok(users) => {
                 Response::Success(users.into_iter().map(|user| Passwd::from(user)).collect())
             }
             Err(err) => {
                 log::error!("Failed to get all users: {:?}", err);
-                Response::Unavail
+                Response::TryAgain
             }
         }
     }
 
     fn get_entry_by_uid(uid: libc::uid_t) -> libnss::interop::Response<Passwd> {
+        let access_token = match crate::AUTH.lock().unwrap().get_access_token() {
+            Ok(token) => token.clone(),
+            Err(err) => {
+                log::error!("Failed to get access token: {:?}", err);
+                return Response::TryAgain;
+            }
+        };
         match get_user_by_uid(
             &crate::CONFIG.keycloak,
             &crate::CONFIG.mapping,
-            crate::AUTH.lock().unwrap().get_access_token().unwrap(),
+            &access_token,
             uid,
         ) {
             Ok(Some(user)) => Response::Success(Passwd::from(user)),
             Ok(None) => Response::NotFound,
             Err(err) => {
                 log::error!("Failed to get user by uid: {:?}", err);
-                Response::Unavail
+                Response::TryAgain
             }
         }
     }
 
     fn get_entry_by_name(name: String) -> libnss::interop::Response<Passwd> {
+        let access_token = match crate::AUTH.lock().unwrap().get_access_token() {
+            Ok(token) => token.clone(),
+            Err(err) => {
+                log::error!("Failed to get access token: {:?}", err);
+                return Response::TryAgain;
+            }
+        };
         match get_user_by_name(
             &crate::CONFIG.keycloak,
             &crate::CONFIG.mapping,
-            crate::AUTH.lock().unwrap().get_access_token().unwrap(),
+            &access_token,
             &name,
         ) {
             Ok(Some(user)) => Response::Success(Passwd::from(user)),
             Ok(None) => Response::NotFound,
             Err(err) => {
                 log::error!("Failed to get user by name: {:?}", err);
-                Response::Unavail
+                Response::TryAgain
             }
         }
     }


### PR DESCRIPTION
Update authentication procedure to propagate an error when Keycloak cannot be reached. Also, test for the error in the top level functions and return Retry instead of Unavail. This will allow the NSS plugin to retry the authentication procedure instead of failing fatally.